### PR TITLE
Add gcp-kms-key flag

### DIFF
--- a/artifact/gcp/signer_test.go
+++ b/artifact/gcp/signer_test.go
@@ -177,8 +177,11 @@ func TestKMSSignatureCompatibility(t *testing.T) {
 				client:     &fakeKMSClient{},
 				rpcTimeout: 60 * time.Second,
 			}
-			goldenSigner := artifact.NewSigner([]byte(availableKMSKeys[keyName].private))
-			goldenVerifier := artifact.NewVerifier([]byte(availableKMSKeys[keyName].public))
+			goldenSigner, err := artifact.NewPKISigner([]byte(availableKMSKeys[keyName].private))
+			if err != nil {
+				t.Errorf("NewPKISigner: %v", err)
+				return
+			}
 
 			// Sign with Google KMS, verify with golden verifier.
 			sig, err := kmsSigner.Sign(msg)
@@ -186,7 +189,7 @@ func TestKMSSignatureCompatibility(t *testing.T) {
 				t.Errorf("Sign: %v", err)
 				return
 			}
-			if err := goldenVerifier.Verify(msg, sig); err != nil {
+			if err := goldenSigner.Verify(msg, sig); err != nil {
 				t.Errorf("Golden Verify: %v", err)
 				return
 			}

--- a/artifact/signer_test.go
+++ b/artifact/signer_test.go
@@ -112,6 +112,18 @@ BlUY/oCrAGUGN10F49+c
 -----END DSA PRIVATE KEY-----`
 )
 
+func mustCreateSigner(t *testing.T, key []byte) *PKISigner {
+	s, err := NewPKISigner(key)
+	assert.NoError(t, err)
+	return s
+}
+
+func mustCreateVerifier(t *testing.T, key []byte) *PKISigner {
+	v, err := NewPKIVerifier(key)
+	assert.NoError(t, err)
+	return v
+}
+
 func TestPublicKey(t *testing.T) {
 	m, err := GetKeyAndVerifyMethod([]byte(PublicRSAKey))
 	assert.NoError(t, err)
@@ -162,17 +174,17 @@ func TestPrivateKey(t *testing.T) {
 func TestRSA(t *testing.T) {
 	msg := []byte("this is secret message")
 
-	s := NewSigner([]byte(PrivateRSAKey))
+	s := mustCreateSigner(t, []byte(PrivateRSAKey))
 	sig, err := s.Sign(msg)
 	assert.NoError(t, err)
 	assert.NotNil(t, sig)
 
-	v := NewVerifier([]byte(PublicRSAKey))
+	v := mustCreateVerifier(t, []byte(PublicRSAKey))
 	err = v.Verify(msg, sig)
 	assert.NoError(t, err)
 
 	// use invalid key
-	v = NewVerifier([]byte(PublicRSAKeyError))
+	v = mustCreateVerifier(t, []byte(PublicRSAKeyError))
 	err = v.Verify(msg, sig)
 	assert.Error(t, err)
 	assert.Contains(t, errors.Cause(err).Error(), "verification error")
@@ -191,23 +203,23 @@ func TestRSARaw(t *testing.T) {
 func TestECDSA(t *testing.T) {
 	msg := []byte("this is secret message")
 
-	s := NewSigner([]byte(PrivateECDSAKey))
+	s := mustCreateSigner(t, []byte(PrivateECDSAKey))
 	sig, err := s.Sign(msg)
 	assert.NoError(t, err)
 	assert.NotNil(t, sig)
 
-	v := NewVerifier([]byte(PublicECDSAKey))
+	v := mustCreateVerifier(t, []byte(PublicECDSAKey))
 	err = v.Verify(msg, sig)
 	assert.NoError(t, err)
 
 	// use invalid key
-	v = NewVerifier([]byte(PublicECDSAKeyError))
+	v = mustCreateVerifier(t, []byte(PublicECDSAKeyError))
 	err = v.Verify(msg, sig)
 	assert.Error(t, err)
 	assert.Contains(t, errors.Cause(err).Error(), "verification failed")
 
 	// use invalid signature
-	v = NewVerifier([]byte(PublicECDSAKey))
+	v = mustCreateVerifier(t, []byte(PublicECDSAKey))
 	// change the first byte of the signature
 	sig, err = s.Sign([]byte("this is a different message"))
 	assert.NoError(t, err)
@@ -217,7 +229,7 @@ func TestECDSA(t *testing.T) {
 	assert.Contains(t, errors.Cause(err).Error(), "verification failed")
 
 	// use broken key
-	v = NewVerifier([]byte("broken key"))
+	v = mustCreateVerifier(t, []byte("broken key"))
 	err = v.Verify(msg, sig)
 	assert.Error(t, err)
 	assert.Contains(t, errors.Cause(err).Error(), "failed to parse")

--- a/awriter/signer.go
+++ b/awriter/signer.go
@@ -27,7 +27,7 @@ var ErrManifestNotFound = errors.New("`manifest` not found. Corrupt Artifact?")
 
 // Special fast-track to just sign, nothing else. This skips all the expensive
 // and complicated repacking, and simply adds the manifest.sig file.
-func SignExisting(src io.Reader, dst io.Writer, key []byte, overwrite bool) error {
+func SignExisting(src io.Reader, dst io.Writer, key artifact.Signer, overwrite bool) error {
 	var foundManifest bool
 	rTar := tar.NewReader(src)
 	wTar := tar.NewWriter(dst)
@@ -78,8 +78,7 @@ func SignExisting(src io.Reader, dst io.Writer, key []byte, overwrite bool) erro
 	return nil
 }
 
-func signManifestAndOutputSignature(header *tar.Header, src *tar.Reader, dst *tar.Writer, key []byte) error {
-	signer := artifact.NewSigner(key)
+func signManifestAndOutputSignature(header *tar.Header, src *tar.Reader, dst *tar.Writer, key artifact.Signer) error {
 	buf := make([]byte, header.Size)
 	read, err := src.Read(buf)
 	if err != nil && err != io.EOF {
@@ -99,7 +98,7 @@ func signManifestAndOutputSignature(header *tar.Header, src *tar.Reader, dst *ta
 		return errors.New("Could not write entire manifest")
 	}
 
-	signedBuf, err := signer.Sign(buf)
+	signedBuf, err := key.Sign(buf)
 	if err != nil {
 		return errors.Wrap(err, "Could not sign manifest")
 	}

--- a/awriter/writer_test.go
+++ b/awriter/writer_test.go
@@ -68,6 +68,12 @@ func checkTarElementsByName(r io.Reader, expected []string) error {
 	return nil
 }
 
+func mustCreateSigner(t *testing.T, key []byte) artifact.Signer {
+	s, err := artifact.NewPKISigner(key)
+	assert.NoError(t, err)
+	return s
+}
+
 func TestWriteArtifactWrongVersion(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
 	w := NewWriter(buf, artifact.NewCompressorGzip())
@@ -210,7 +216,7 @@ func TestWriteArtifactV2(t *testing.T) {
 
 	buf := bytes.NewBuffer(nil)
 
-	s := artifact.NewSigner([]byte(PrivateKey))
+	s := mustCreateSigner(t, []byte(PrivateKey))
 	w := NewWriterSigned(buf, comp, s)
 
 	upd, err := MakeFakeUpdate("my test update")
@@ -267,7 +273,7 @@ func TestWriteArtifactV3(t *testing.T) {
 
 	buf := bytes.NewBuffer(nil)
 
-	s := artifact.NewSigner([]byte(PrivateKey))
+	s := mustCreateSigner(t, []byte(PrivateKey))
 	w := NewWriterSigned(buf, comp, s)
 
 	upd, err := MakeFakeUpdate("my test update")
@@ -359,7 +365,7 @@ func TestWriteArtifactV3(t *testing.T) {
 
 	// Signed artifact V3
 	buf.Reset()
-	s = artifact.NewSigner([]byte(PrivateKey))
+	s = mustCreateSigner(t, []byte(PrivateKey))
 	w = NewWriterSigned(buf, comp, s)
 	upd, err = MakeFakeUpdate("my test update")
 	assert.NoError(t, err)
@@ -545,7 +551,7 @@ func TestWriteArtifactV3(t *testing.T) {
 
 	// Signed artifact V3 with augments section.
 	buf.Reset()
-	s = artifact.NewSigner([]byte(PrivateKey))
+	s = mustCreateSigner(t, []byte(PrivateKey))
 	w = NewWriterSigned(buf, comp, s)
 	upd, err = MakeFakeUpdate("my test update")
 	assert.NoError(t, err)
@@ -673,7 +679,7 @@ func TestWriteManifestVersion(t *testing.T) {
 			version: 2,
 			mchk:    artifact.NewChecksumStore(),
 			tw:      tar.NewWriter(&TestErrWriter{FailOnWriteData: []byte("manifest.sig")}),
-			signer:  artifact.NewSigner([]byte(PrivateKey)),
+			signer:  mustCreateSigner(t, []byte(PrivateKey)),
 			err:     "writer: can not tar signature",
 		},
 		"version 3, fail on write to manifest checksum store": {
@@ -686,7 +692,7 @@ func TestWriteManifestVersion(t *testing.T) {
 			version: 3,
 			mchk:    artifact.NewChecksumStore(),
 			tw:      tar.NewWriter(&TestErrWriter{FailOnWriteData: []byte("manifest.sig")}),
-			signer:  artifact.NewSigner([]byte(PrivateKey)),
+			signer:  mustCreateSigner(t, []byte(PrivateKey)),
 			err:     "writer: can not tar signature",
 		},
 		"version 3, fail write augmented-manifest": {
@@ -694,7 +700,7 @@ func TestWriteManifestVersion(t *testing.T) {
 			mchk:    artifact.NewChecksumStore(),
 			augmchk: augmentedChecksumStore,
 			tw:      tar.NewWriter(&TestErrWriter{FailOnWriteData: []byte("manifest-augment")}),
-			signer:  artifact.NewSigner([]byte(PrivateKey)),
+			signer:  mustCreateSigner(t, []byte(PrivateKey)),
 			err:     "writer: can not write manifest stream",
 		},
 	}

--- a/cli/artifacts.go
+++ b/cli/artifacts.go
@@ -15,6 +15,8 @@
 package cli
 
 import (
+	"context"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -22,8 +24,10 @@ import (
 
 	"github.com/mendersoftware/mender-artifact/areader"
 	"github.com/mendersoftware/mender-artifact/artifact"
+	"github.com/mendersoftware/mender-artifact/artifact/gcp"
 	"github.com/mendersoftware/mender-artifact/awriter"
 	"github.com/mendersoftware/mender-artifact/handlers"
+	"github.com/urfave/cli"
 
 	"github.com/pkg/errors"
 )
@@ -111,16 +115,57 @@ func scripts(scripts []string) (*artifact.Scripts, error) {
 	return &scr, nil
 }
 
-func getKey(keyPath string) ([]byte, error) {
-	if keyPath == "" {
-		return nil, nil
-	}
+type SigningKey interface {
+	artifact.Signer
+	artifact.Verifier
+}
 
-	key, err := ioutil.ReadFile(keyPath)
-	if err != nil {
-		return nil, errors.Wrap(err, "Error reading key file")
+func getKey(c *cli.Context) (SigningKey, error) {
+	var chosenOptions []string
+	possibleOptions := []string{"key", "gcp-kms-key"}
+	for _, optName := range possibleOptions {
+		if c.String(optName) == "" {
+			continue
+		}
+		chosenOptions = append(chosenOptions, optName)
 	}
-	return key, nil
+	if len(chosenOptions) == 0 {
+		return nil, nil
+	} else if len(chosenOptions) > 1 {
+		return nil, fmt.Errorf("too many signing keys given: %v", chosenOptions)
+	}
+	switch chosenOption := chosenOptions[0]; chosenOption {
+	case "key":
+		key, err := ioutil.ReadFile(c.String("key"))
+		if err != nil {
+			return nil, errors.Wrap(err, "Error reading key file")
+		}
+
+		// The "key" flag can either be public or private depending on the
+		// command name. Explicitly map each command's name to which one it
+		// should be, so we return the correct key type.
+		publicKeyCommands := map[string]bool{
+			"validate": true,
+			"read":     true,
+		}
+		privateKeyCommands := map[string]bool{
+			"rootfs-image": true,
+			"sign":         true,
+			"modify":       true,
+			"copy":         true,
+		}
+		if publicKeyCommands[c.Command.Name] {
+			return artifact.NewPKIVerifier(key)
+		}
+		if privateKeyCommands[c.Command.Name] {
+			return artifact.NewPKISigner(key)
+		}
+		return nil, fmt.Errorf("unsupported command %q with %q flag, please add command to allowlist", c.Command.Name, "key")
+	case "gcp-kms-key":
+		return gcp.NewKMSSigner(context.TODO(), c.String("gcp-kms-key"))
+	default:
+		return nil, fmt.Errorf("unsupported signing key type %q", chosenOption)
+	}
 }
 
 func unpackArtifact(name string) (ua *unpackedArtifact, err error) {
@@ -325,10 +370,10 @@ func reconstructArtifactWriteData(ua *unpackedArtifact) (*awriter.WriteArtifactA
 	return args, nil
 }
 
-func repack(comp artifact.Compressor, ua *unpackedArtifact, to io.Writer, key []byte) error {
+func repack(comp artifact.Compressor, ua *unpackedArtifact, to io.Writer, key SigningKey) error {
 	aWriter := awriter.NewWriter(to, comp)
 	if key != nil {
-		aWriter = awriter.NewWriterSigned(to, comp, artifact.NewSigner(key))
+		aWriter = awriter.NewWriterSigned(to, comp, key)
 	}
 
 	// for rootfs-images: Update rootfs-image.checksum provide if there is one.
@@ -348,7 +393,7 @@ func repack(comp artifact.Compressor, ua *unpackedArtifact, to io.Writer, key []
 	return aWriter.WriteArtifact(ua.writeArgs)
 }
 
-func repackArtifact(comp artifact.Compressor, key []byte, ua *unpackedArtifact) error {
+func repackArtifact(comp artifact.Compressor, key SigningKey, ua *unpackedArtifact) error {
 	tmp, err := ioutil.TempFile(filepath.Dir(ua.origPath), "mender-artifact")
 	if err != nil {
 		return err

--- a/cli/artifacts_test.go
+++ b/cli/artifacts_test.go
@@ -65,7 +65,11 @@ func WriteTestArtifact(version int, update string, key []byte) (io.Reader, error
 
 	aw := new(awriter.Writer)
 	if key != nil {
-		aw = awriter.NewWriterSigned(buff, comp, artifact.NewSigner(key))
+		s, err := artifact.NewPKISigner(key)
+		if err != nil {
+			return nil, errors.Wrap(err, "artifact.NewPKISigner")
+		}
+		aw = awriter.NewWriterSigned(buff, comp, s)
 		fmt.Println("write signed artifact")
 	} else {
 		aw = awriter.NewWriter(buff, comp)

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -127,6 +127,12 @@ func getCliContext() *cli.App {
 			"the Artifact.",
 	}
 
+	gcpKMSKeyFlag := cli.StringFlag{
+		Name: "gcp-kms-key",
+		Usage: "Resource ID of the GCP KMS key that will be used to sign " +
+			"the Artifact.",
+	}
+
 	publicKeyFlag := cli.StringFlag{
 		Name: "key, k",
 		Usage: "Full path to the public key that will be used to verify " +
@@ -227,6 +233,7 @@ func getCliContext() *cli.App {
 			Value: LatestFormatVersion,
 		},
 		privateKeyFlag,
+		gcpKMSKeyFlag,
 		cli.StringSliceFlag{
 			Name: "script, s",
 			Usage: "Full path to the state script(s). You can specify multiple " +
@@ -390,7 +397,10 @@ func getCliContext() *cli.App {
 		Action:      validateArtifact,
 		UsageText:   "mender-artifact validate [options] <pathspec>",
 		Description: "This command validates artifact file provided by pathspec.",
-		Flags:       []cli.Flag{publicKeyFlag},
+		Flags: []cli.Flag{
+			publicKeyFlag,
+			gcpKMSKeyFlag,
+		},
 	}
 
 	//
@@ -405,6 +415,7 @@ func getCliContext() *cli.App {
 		Description: "This command validates artifact file provided by pathspec.",
 		Flags: []cli.Flag{
 			publicKeyFlag,
+			gcpKMSKeyFlag,
 			cli.BoolFlag{
 				Name:  "no-progress",
 				Usage: "Suppress the progressbar output",
@@ -426,6 +437,7 @@ func getCliContext() *cli.App {
 	}
 	sign.Flags = []cli.Flag{
 		privateKeyFlag,
+		gcpKMSKeyFlag,
 		cli.StringFlag{
 			Name: "output-path, o",
 			Usage: "Full path to output signed artifact file; " +
@@ -488,6 +500,7 @@ func getCliContext() *cli.App {
 			Usage: "Full path to the tenant token that will be injected into modified file.",
 		},
 		privateKeyFlag,
+		gcpKMSKeyFlag,
 		compressionFlag,
 	}
 	modify.Before = func(c *cli.Context) error {
@@ -511,6 +524,7 @@ func getCliContext() *cli.App {
 	copy.Flags = []cli.Flag{
 		compressionFlag,
 		privateKeyFlag,
+		gcpKMSKeyFlag,
 	}
 
 	cat := cli.Command{

--- a/cli/copy.go
+++ b/cli/copy.go
@@ -36,7 +36,7 @@ func Cat(c *cli.Context) (err error) {
 		return cli.NewExitError("The input image does not seem to be a valid image", 1)
 	}
 
-	privateKey, err := getKey(c.String("key"))
+	privateKey, err := getKey(c)
 	if err != nil {
 		return cli.NewExitError("Unable to load key: "+err.Error(), 1)
 	}
@@ -67,7 +67,7 @@ func Copy(c *cli.Context) (err error) {
 			"If you wish to change the compression type, use the <modify> command.")
 	}
 
-	privateKey, err := getKey(c.String("key"))
+	privateKey, err := getKey(c)
 	if err != nil {
 		return cli.NewExitError("Unable to load key: "+err.Error(), 1)
 	}
@@ -137,7 +137,7 @@ func Copy(c *cli.Context) (err error) {
 // a mender artifact, or an sdimg.
 func Install(c *cli.Context) (err error) {
 
-	privateKey, err := getKey(c.String("key"))
+	privateKey, err := getKey(c)
 	if err != nil {
 		return cli.NewExitError("Unable to load key: "+err.Error(), 1)
 	}
@@ -220,7 +220,7 @@ func Remove(c *cli.Context) (err error) {
 		}
 	}
 
-	privateKey, err := getKey(c.String("key"))
+	privateKey, err := getKey(c)
 	if err != nil {
 		return cli.NewExitError("Unable to load key: "+err.Error(), 1)
 	}

--- a/cli/modify.go
+++ b/cli/modify.go
@@ -32,7 +32,7 @@ func modifyArtifact(c *cli.Context) (err error) {
 		return cli.NewExitError("compressor '"+c.GlobalString("compression")+"' is not supported: "+err.Error(), 1)
 	}
 
-	privateKey, err := getKey(c.String("key"))
+	privateKey, err := getKey(c)
 	if err != nil {
 		return cli.NewExitError("Unable to load key: "+err.Error(), 1)
 	}

--- a/cli/partition.go
+++ b/cli/partition.go
@@ -82,7 +82,7 @@ type ModImageArtifact struct {
 	ModImageBase
 	*unpackedArtifact
 	comp artifact.Compressor
-	key  []byte
+	key  SigningKey
 }
 
 type ModImageSdimg struct {
@@ -108,7 +108,7 @@ type vImageAndDir struct {
 
 // Open is a utility function that parses an input image and returns a
 // V(irtual)P(artition)Image.
-func (v vImage) Open(key []byte, imgname string, overrideCompressor ...artifact.Compressor) (VPImage, error) {
+func (v vImage) Open(key SigningKey, imgname string, overrideCompressor ...artifact.Compressor) (VPImage, error) {
 	// first we need to check  if we are having artifact or image file
 	art, err := os.Open(imgname)
 	if err != nil {
@@ -156,7 +156,7 @@ func (v vImage) Open(key []byte, imgname string, overrideCompressor ...artifact.
 // Shortcut to use an image with one file. This is inefficient if you are going
 // to write more than one file, since it writes out the entire image
 // afterwards. In that case use VPImage and VPFile instead.
-func (v vImage) OpenFile(key []byte, imgAndPath string) (VPFile, error) {
+func (v vImage) OpenFile(key SigningKey, imgAndPath string) (VPFile, error) {
 	imagepath, filepath, err := parseImgPath(imgAndPath)
 	if err != nil {
 		return nil, err
@@ -180,7 +180,7 @@ func (v vImage) OpenFile(key []byte, imgAndPath string) (VPFile, error) {
 }
 
 // Shortcut to use an image with one directory.
-func (v vImage) OpenDir(key []byte, imgAndPath string) (VPDir, error) {
+func (v vImage) OpenDir(key SigningKey, imgAndPath string) (VPDir, error) {
 	imagepath, dirpath, err := parseImgPath(imgAndPath)
 	if err != nil {
 		return nil, err

--- a/cli/read.go
+++ b/cli/read.go
@@ -47,12 +47,13 @@ func readArtifact(c *cli.Context) error {
 
 	var verifyCallback areader.SignatureVerifyFn
 
-	key, err := getKey(c.String("key"))
+	key, err := getKey(c)
 	if err != nil {
 		return cli.NewExitError(err.Error(), errArtifactInvalidParameters)
 	}
-	s := artifact.NewVerifier(key)
-	verifyCallback = s.Verify
+	if key != nil {
+		verifyCallback = key.Verify
+	}
 
 	// if key is not provided just continue reading artifact returning
 	// info that signature can not be verified
@@ -60,7 +61,7 @@ func readArtifact(c *cli.Context) error {
 	ver := func(message, sig []byte) error {
 		sigInfo = "signed but no key for verification provided; " +
 			"please use `-k` option for providing verification key"
-		if c.String("key") != "" {
+		if key != nil {
 			err = verifyCallback(message, sig)
 			if err != nil {
 				sigInfo = "signed; verification using provided key failed"

--- a/cli/sign.go
+++ b/cli/sign.go
@@ -30,12 +30,7 @@ func signExisting(c *cli.Context) error {
 			" to say 'artifacts sign <pathspec>'?", 1)
 	}
 
-	if len(c.String("key")) == 0 {
-		return cli.NewExitError("Missing signing key; "+
-			"please use `-k` parameter for providing one", 1)
-	}
-
-	privateKey, err := getKey(c.String("key"))
+	privateKey, err := getKey(c)
 	if err != nil {
 		return cli.NewExitError("Can not use signing key provided: "+err.Error(), 1)
 	}

--- a/cli/validate.go
+++ b/cli/validate.go
@@ -26,20 +26,16 @@ import (
 	"github.com/urfave/cli"
 )
 
-func validate(art io.Reader, key []byte) error {
+func validate(art io.Reader, key artifact.Verifier) error {
 	// do not return error immediately if we can not validate signature;
 	// just continue checking consistency and return info if
 	// signature verification failed
 	var validationError error
 
-	// Some callers pass nil, others pass "", to indicate a missing public key.
-	keyIsSpecified := (key != nil) && (len(key) > 0)
-
 	ar := areader.NewReader(art)
 	ar.VerifySignatureCallback = func(message, sig []byte) error {
-		if keyIsSpecified {
-			s := artifact.NewVerifier(key)
-			if err := s.Verify(message, sig); err != nil {
+		if key != nil {
+			if err := key.Verify(message, sig); err != nil {
 				validationError = err
 			}
 		}
@@ -52,10 +48,10 @@ func validate(art io.Reader, key []byte) error {
 	if validationError != nil {
 		return validationError
 	}
-	if keyIsSpecified && !ar.IsSigned {
+	if key != nil && !ar.IsSigned {
 		return errors.New("missing signature")
 	}
-	if !keyIsSpecified && ar.IsSigned {
+	if key == nil && ar.IsSigned {
 		return errors.New("missing key")
 	}
 	return nil
@@ -67,7 +63,7 @@ func validateArtifact(c *cli.Context) error {
 			" to say 'artifacts validate <pathspec>'?", errArtifactInvalidParameters)
 	}
 
-	key, err := getKey(c.String("key"))
+	key, err := getKey(c)
 	if err != nil {
 		return cli.NewExitError(err.Error(), errArtifactInvalidParameters)
 	}

--- a/cli/validate_test.go
+++ b/cli/validate_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/mendersoftware/mender-artifact/artifact"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
@@ -81,7 +82,9 @@ func TestValidate(t *testing.T) {
 		fmt.Printf("---- Running test validate-%d ----\n", i)
 		art, err := WriteTestArtifact(test.version, "", test.writeKey)
 		assert.NoError(t, err)
-		err = validate(art, test.validateKey)
+		validater, err := artifact.NewPKIVerifier(test.validateKey)
+		assert.NoError(t, err)
+		err = validate(art, validater)
 		if test.expectedError == "" {
 			assert.NoError(t, err)
 		} else {

--- a/cli/write.go
+++ b/cli/write.go
@@ -185,7 +185,7 @@ func writeRootfs(c *cli.Context) error {
 		os.Remove(name + ".tmp")
 	}()
 
-	aw, err := artifactWriter(comp, f, c.String("key"), version)
+	aw, err := artifactWriter(c, comp, f, version)
 	if err != nil {
 		return cli.NewExitError(err.Error(), 1)
 	}
@@ -270,18 +270,18 @@ func reportProgress(c context.Context, state chan string) {
 	}
 }
 
-func artifactWriter(comp artifact.Compressor, f *os.File, key string,
+func artifactWriter(c *cli.Context, comp artifact.Compressor, f *os.File,
 	ver int) (*awriter.Writer, error) {
-	if key != "" {
+	privateKey, err := getKey(c)
+	if err != nil {
+		return nil, err
+	}
+	if privateKey != nil {
 		if ver == 0 {
 			// check if we are having correct version
 			return nil, errors.New("can not use signed artifact with version 0")
 		}
-		privateKey, err := getKey(key)
-		if err != nil {
-			return nil, err
-		}
-		return awriter.NewWriterSigned(f, comp, artifact.NewSigner(privateKey)), nil
+		return awriter.NewWriterSigned(f, comp, privateKey), nil
 	}
 	return awriter.NewWriter(f, comp), nil
 }
@@ -607,7 +607,7 @@ func writeModuleImage(ctx *cli.Context) error {
 		os.Remove(name + ".tmp")
 	}()
 
-	aw, err := artifactWriter(comp, f, ctx.String("key"), version)
+	aw, err := artifactWriter(ctx, comp, f, version)
 	if err != nil {
 		return cli.NewExitError(err.Error(), 1)
 	}


### PR DESCRIPTION
Enable signing the artifact by passing the --gcp-kms-key flag. This
signs the artifact without the user ever having access to the signing
key.